### PR TITLE
Remove folder path from generated topic branch name

### DIFF
--- a/src/Components/formView.tsx
+++ b/src/Components/formView.tsx
@@ -114,9 +114,11 @@ export class FormView extends React.Component<Props, FormState> {
     const { targets, pullRequest } = this.props;
     const rowIndex = findIndex(id, targets);
     const targetBranchName = newValue.text || "";
-    let newTargets = [...targets];
+    const newTargets = [...targets];
+
+    const sanitizedTargetSuffix = targetBranchName.replace(/\//g, "-");
     let generatedTopicBranchName = trimStart(
-      `${pullRequest.sourceRefName}-on-${targetBranchName}`,
+      `${pullRequest.sourceRefName}-on-${sanitizedTargetSuffix}`,
       "refs/heads/"
     );
 
@@ -131,7 +133,7 @@ export class FormView extends React.Component<Props, FormState> {
       targets.some(target => target.topicBranch === generatedTopicBranchName)
     ) {
       generatedTopicBranchName = trimStart(
-        `${pullRequest.sourceRefName}-on-${targetBranchName}-${count}`,
+        `${pullRequest.sourceRefName}-on-${sanitizedTargetSuffix}-${count}`,
         "refs/heads/"
       );
       count++;


### PR DESCRIPTION
Currently, the generated topic branch name will just append the target branch to the context PR's source branch name. Where this causes issues is when the target branch is within a folder. This will muddy up where the topic branch gets placed. This change replaces the path separator with dashes, so that the topic branch gets placed in the same folder as the target branch by default.

## Current
![Screen Shot 2019-05-17 at 1 40 42 PM](https://user-images.githubusercontent.com/8703324/57955179-f8c55980-78a9-11e9-9ece-a425efbd934b.png)

## Proposed
![Screen Shot 2019-05-17 at 1 39 56 PM](https://user-images.githubusercontent.com/8703324/57955184-0084fe00-78aa-11e9-88de-e54e5b93883a.png)