### PR TITLE
Add better support for Azure DevOps Server

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -27,9 +27,10 @@ export function trimStart(target: string, trim: string): string {
 export function formatPrUrl(item: GitPullRequest): string {
   const host = SDK.getHost();
 
-  const link = `https://dev.azure.com/${host.name}/${
-    item.repository.project.name
-  }/_git/${item.repository.name}/pullrequest/${item.pullRequestId}`;
+  const baseUrl = item.url.split("/_apis")[0];
+  const link = `${baseUrl}/_git/${item.repository.name}/pullrequest/${
+    item.pullRequestId
+  }`;
 
   return link;
 }
@@ -40,9 +41,10 @@ export function formatCherryPickUrl(item: GitCherryPick): string {
   let refName = trimStart(item.parameters.generatedRefName, "refs/heads/");
   refName = encodeURIComponent(refName);
 
-  const link = `https://dev.azure.com/${host.name}/${
-    item.parameters.repository.project.name
-  }/_git/${item.parameters.repository.name}?version=GB${refName}`;
+  const baseUrl = item.url.split("/_apis")[0];
+  const link = `${baseUrl}/_git/${
+    item.parameters.repository.name
+  }?version=GB${refName}`;
 
   return link;
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -4,7 +4,7 @@
   "id": "pr-multi-cherry-pick",
   "name": "PR Multi-Cherry-Pick",
   "description": "Cherry-pick a PR's commits into multiple branches at once",
-  "demands": ["api-version/3.0"],
+  "demands": ["api-version/5.0"],
   "scopes": ["vso.code_full"],
   "categories": ["Azure Repos"],
   "targets": [


### PR DESCRIPTION
Change required api-version to include only > Azure DevOps Server 2019
Format url for cherry-pick and pr for server instances