### PR TITLE
Decrease extension scope to vso.code_manage

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,11 +1,11 @@
 {
   "manifestVersion": 1,
-  "version": "0.0.61",
+  "version": "0.0.65",
   "id": "pr-multi-cherry-pick",
   "name": "PR Multi-Cherry-Pick",
   "description": "Cherry-pick a PR's commits into multiple branches at once",
   "demands": ["api-version/5.0"],
-  "scopes": ["vso.code_full"],
+  "scopes": ["vso.code_manage"],
   "categories": ["Azure Repos"],
   "targets": [
     {


### PR DESCRIPTION
vso.code_manage is the minimum scope that is needed for all of the REST apis the extension calls. It's worth noting that the [POST cherrypicks/create](https://docs.microsoft.com/en-us/rest/api/azure/devops/git/cherry%20picks/create?view=azure-devops-rest-5.1) is what requires this scope